### PR TITLE
Fix for: Exception Livewire Calendar not correctly configured. Check initial inputs.

### DIFF
--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -66,23 +66,25 @@ class LivewireCalendar extends Component
         'gridEndsAt' => 'date',
     ];
 
-    public function mount($initialYear = null,
-                          $initialMonth = null,
-                          $weekStartsAt = null,
-                          $calendarView = null,
-                          $dayView = null,
-                          $eventView = null,
-                          $dayOfWeekView = null,
-                          $dragAndDropClasses = null,
-                          $beforeCalendarView = null,
-                          $afterCalendarView = null,
-                          $pollMillis = null,
-                          $pollAction = null,
-                          $dragAndDropEnabled = true,
-                          $dayClickEnabled = true,
-                          $eventClickEnabled = true,
-                          $extras = [])
-    {
+    public function mount(
+        $initialYear = null,
+        $initialMonth = null,
+        $weekStartsAt = null,
+        $calendarView = null,
+        $dayView = null,
+        $eventView = null,
+        $dayOfWeekView = null,
+        $dragAndDropClasses = null,
+        $beforeCalendarView = null,
+        $afterCalendarView = null,
+        $pollMillis = null,
+        $pollAction = null,
+        $dragAndDropEnabled = true,
+        $dayClickEnabled = true,
+        $eventClickEnabled = true,
+        $extras = []
+                          
+    ) {
         $this->weekStartsAt = $weekStartsAt ?? Carbon::SUNDAY;
         $this->weekEndsAt = $this->weekStartsAt == Carbon::SUNDAY
             ? Carbon::SATURDAY
@@ -115,13 +117,14 @@ class LivewireCalendar extends Component
         //
     }
 
-    public function setupViews($calendarView = null,
-                               $dayView = null,
-                               $eventView = null,
-                               $dayOfWeekView = null,
-                               $beforeCalendarView = null,
-                               $afterCalendarView = null)
-    {
+    public function setupViews(
+        $calendarView = null,
+        $dayView = null,
+        $eventView = null,
+        $dayOfWeekView = null,
+        $beforeCalendarView = null,
+        $afterCalendarView = null
+    ) {
         $this->calendarView = $calendarView ?? 'livewire-calendar::calendar';
         $this->dayView = $dayView ?? 'livewire-calendar::day';
         $this->eventView = $eventView ?? 'livewire-calendar::event';
@@ -140,7 +143,8 @@ class LivewireCalendar extends Component
     public function goToPreviousMonth()
     {
         $this->startsAt->subMonthNoOverflow();
-        $this->endsAt->subMonthNoOverflow();
+        // $this->endsAt->subMonthNoOverflow();
+        $this->endsAt = $this->startsAt->clone()->endOfMonth()->startOfDay();
 
         $this->calculateGridStartsEnds();
     }
@@ -148,7 +152,8 @@ class LivewireCalendar extends Component
     public function goToNextMonth()
     {
         $this->startsAt->addMonthNoOverflow();
-        $this->endsAt->addMonthNoOverflow();
+        // $this->endsAt->addMonthNoOverflow();
+        $this->endsAt = $this->startsAt->clone()->endOfMonth()->startOfDay();
 
         $this->calculateGridStartsEnds();
     }


### PR DESCRIPTION
There was an error when changing month in certain circumstances, see: [asantibanez/livewire-calendar#22](https://github.com/asantibanez/livewire-calendar/issues/22)

I used the code others did to fix it, thanks for their input.
Specifically this commit from @nohumans https://github.com/nohumans/livewire-calendar/commit/dd6841d385815c0ad1a0a5df611fb2e16644adc3