### PR TITLE
Add Livewire 4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .idea/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0|^8.1|^8.2",
+        "php": "^7.4|^8.0|^8.1|^8.2|^8.3|^8.4",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "livewire/livewire": "^2.0||^3.0"
+        "livewire/livewire": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -228,14 +228,21 @@ class LivewireCalendar extends Component
 
     public function getId()
     {
-        if (!empty($this->__id)) {
-            $id = $this->__id;
-        } else if (!empty($this->id)) {
-            $id = $this->id;
-        } else {
-            $id = 'livewire-calendar-' . uniqid();
+        // Livewire 3+ has getId() on base Component class
+        if (method_exists(parent::class, 'getId')) {
+            return parent::getId();
         }
-        return $id;
+
+        // Fallback for Livewire 2
+        if (!empty($this->__id)) {
+            return $this->__id;
+        }
+
+        if (!empty($this->id)) {
+            return $this->id;
+        }
+
+        return 'livewire-calendar-' . uniqid();
     }
 
     /**

--- a/tests/LivewireCalendarTest.php
+++ b/tests/LivewireCalendarTest.php
@@ -3,38 +3,28 @@
 namespace Omnia\LivewireCalendar\Tests;
 
 use Omnia\LivewireCalendar\LivewireCalendar;
-use Livewire\LivewireManager;
-use Livewire\Testing\TestableLivewire;
+use Livewire\Livewire;
 
 class LivewireCalendarTest extends TestCase
 {
-    private function createComponent($parameters = []) : TestableLivewire
+    private function createComponent($parameters = [])
     {
-        return app(LivewireManager::class)->test(LivewireCalendar::class, $parameters);
+        return Livewire::test(LivewireCalendar::class, $parameters);
     }
 
-    /** @test */
-    public function can_build_component()
+    public function test_can_build_component()
     {
-        //Arrange
-
-        //Act
         $component = $this->createComponent([]);
 
-        //Assert
         $this->assertNotNull($component);
     }
 
-    /** @test */
-    public function can_navigate_to_next_month()
+    public function test_can_navigate_to_next_month()
     {
-        //Arrange
         $component = $this->createComponent([]);
 
-        //Act
-        $component->runAction('goToNextMonth');
+        $component->call('goToNextMonth');
 
-        //Assert
         $this->assertEquals(
             today()->startOfMonth()->addMonthNoOverflow(),
             $component->get('startsAt')
@@ -46,16 +36,12 @@ class LivewireCalendarTest extends TestCase
         );
     }
 
-    /** @test */
-    public function can_navigate_to_previous_month()
+    public function test_can_navigate_to_previous_month()
     {
-        //Arrange
         $component = $this->createComponent([]);
 
-        //Act
-        $component->runAction('goToPreviousMonth');
+        $component->call('goToPreviousMonth');
 
-        //Assert
         $this->assertEquals(
             today()->startOfMonth()->subMonthNoOverflow(),
             $component->get('startsAt')
@@ -67,20 +53,16 @@ class LivewireCalendarTest extends TestCase
         );
     }
 
-    /** @test */
-    public function can_navigate_to_current_month()
+    public function test_can_navigate_to_current_month()
     {
-        //Arrange
         $component = $this->createComponent([]);
 
-        $component->runAction('goToPreviousMonth');
-        $component->runAction('goToPreviousMonth');
-        $component->runAction('goToPreviousMonth');
+        $component->call('goToPreviousMonth');
+        $component->call('goToPreviousMonth');
+        $component->call('goToPreviousMonth');
 
-        //Act
-        $component->runAction('goToCurrentMonth');
+        $component->call('goToCurrentMonth');
 
-        //Assert
         $this->assertEquals(
             today()->startOfMonth(),
             $component->get('startsAt')


### PR DESCRIPTION
## Summary
Add Livewire 4 support while maintaining backward compatibility with Livewire 2 and 3.

## Changes
- Update composer.json to support Livewire ^4.0 and testbench for Laravel 7-12
- Update getId() method to prefer parent implementation for Livewire 3+/4
- Modernize tests for PHPUnit 12 compatibility using test_ prefix and Livewire facade

## Verification
All 4 tests pass with Livewire 4.0.3 on Laravel 12 and PHP 8.4.