### PR TITLE
Fix multi-day events and drag-drop compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,60 @@ public function events(): Collection
 }
 ```
 
+### Multi-Day Events
+
+Events can span multiple days using `start_date` and `end_date` instead of the legacy `date` field:
+
+```php
+public function events(): Collection
+{
+    return collect([
+        [
+            'id' => 1,
+            'title' => 'Conference',
+            'description' => 'Annual Tech Conference',
+            'start_date' => Carbon::parse('2024-03-15'),
+            'end_date' => Carbon::parse('2024-03-17'),
+        ],
+    ]);
+}
+```
+
+This event will appear on March 15, 16, and 17 with visual styling indicating it spans multiple days.
+
+#### Multi-Day Event with Times
+
+You can optionally include `start_time` and `end_time` for display purposes:
+
+```php
+[
+    'id' => 2,
+    'title' => 'Training Session',
+    'start_date' => Carbon::parse('2024-03-20'),
+    'end_date' => Carbon::parse('2024-03-22'),
+    'start_time' => '09:00',
+    'end_time' => '17:00',
+]
+```
+
+The start time will display on the first day, and end time on the last day.
+
+#### Event Metadata in Custom Views
+
+When customizing the event view, multi-day events include additional metadata:
+
+- `$event['is_multiday']` - Boolean, true if event spans multiple days
+- `$event['is_first_day']` - Boolean, true if this is the first day of the event
+- `$event['is_last_day']` - Boolean, true if this is the last day of the event
+- `$event['day_position']` - Integer, which day of the event (1-indexed)
+- `$event['total_days']` - Integer, total number of days the event spans
+
+**Note:** Multi-day events have drag and drop disabled by default.
+
+#### Backwards Compatibility
+
+Existing events using the `date` field will continue to work. The calendar automatically detects which format is being used. If both `date` and `start_date`/`end_date` are present, the new format takes precedence.
+
 Now, we can include our component in any view.
 
 Example
@@ -144,8 +198,9 @@ Example
 />
  ```
 
-You should include scripts with `@livewireCalendarScripts` to enable drag and drop which is turned on by default.
-You must include them after `@livewireScripts`
+**For Livewire 3+:** Drag and drop is now handled via Alpine.js (bundled with Livewire 3+), so `@livewireCalendarScripts` is optional. It's only needed if you've published and customized the views using the legacy inline event handlers.
+
+**For Livewire 2:** You must include scripts with `@livewireCalendarScripts` to enable drag and drop. Include them after `@livewireScripts`:
 
 ```blade
 @livewireScripts

--- a/resources/views/day.blade.php
+++ b/resources/views/day.blade.php
@@ -1,9 +1,19 @@
 
 <div
-    ondragenter="onLivewireCalendarEventDragEnter(event, '{{ $componentId }}', '{{ $day }}', '{{ $dragAndDropClasses }}');"
-    ondragleave="onLivewireCalendarEventDragLeave(event, '{{ $componentId }}', '{{ $day }}', '{{ $dragAndDropClasses }}');"
-    ondragover="onLivewireCalendarEventDragOver(event);"
-    ondrop="onLivewireCalendarEventDrop(event, '{{ $componentId }}', '{{ $day }}', {{ $day->year }}, {{ $day->month }}, {{ $day->day }}, '{{ $dragAndDropClasses }}');"
+    x-data="{ dragOver: false }"
+    x-on:dragenter.prevent="dragOver = true"
+    x-on:dragleave.prevent="dragOver = false"
+    x-on:dragover.prevent
+    x-on:drop.prevent="
+        dragOver = false;
+        $wire.onEventDropped(
+            $event.dataTransfer.getData('id'),
+            {{ $day->year }},
+            {{ $day->month }},
+            {{ $day->day }}
+        )
+    "
+    :class="{ '{{ $dragAndDropClasses }}': dragOver }"
     class="flex-1 h-40 lg:h-48 border border-gray-200 -mt-px -ml-px"
     style="min-width: 10rem;">
 
@@ -35,10 +45,11 @@
                 <div class="grid grid-cols-1 grid-flow-row gap-2">
                     @foreach($events as $event)
                         <div
-                            @if($dragAndDropEnabled)
+                            @if($dragAndDropEnabled && !($event['is_multiday'] ?? false))
                                 draggable="true"
+                                x-on:dragstart="$event.dataTransfer.setData('id', '{{ $event['id'] }}')"
                             @endif
-                            ondragstart="onLivewireCalendarEventDragStart(event, '{{ $event['id'] }}')">
+                        >
                             @include($eventView, [
                                 'event' => $event,
                             ])

--- a/resources/views/event.blade.php
+++ b/resources/views/event.blade.php
@@ -2,12 +2,48 @@
     @if($eventClickEnabled)
         wire:click.stop="onEventClick('{{ $event['id']  }}')"
     @endif
-    class="bg-white rounded-lg border py-2 px-3 shadow-md cursor-pointer">
+    class="py-2 px-3 shadow-md cursor-pointer
+        @if($event['is_multiday'] ?? false)
+            @if($event['is_first_day'] ?? false)
+                rounded-l-lg rounded-r-none border-r-0
+            @elseif($event['is_last_day'] ?? false)
+                rounded-r-lg rounded-l-none border-l-0
+            @else
+                rounded-none border-l-0 border-r-0
+            @endif
+            bg-blue-50 border border-blue-200
+        @else
+            bg-white rounded-lg border
+        @endif
+    ">
 
     <p class="text-sm font-medium">
         {{ $event['title'] }}
+        @if(($event['is_multiday'] ?? false) && ($event['is_first_day'] ?? false))
+            <span class="text-xs text-gray-500 font-normal">
+                ({{ $event['total_days'] ?? 1 }} days)
+            </span>
+        @endif
     </p>
-    <p class="mt-2 text-xs">
-        {{ $event['description'] ?? 'No description' }}
-    </p>
+
+    @if($event['is_first_day'] ?? true)
+        <p class="mt-2 text-xs">
+            {{ $event['description'] ?? 'No description' }}
+        </p>
+    @endif
+
+    {{-- Time display for events with time info --}}
+    @if(isset($event['start_time']) || isset($event['end_time']))
+        <p class="mt-1 text-xs text-gray-500">
+            @if(($event['is_first_day'] ?? true) && isset($event['start_time']))
+                {{ $event['start_time'] }}
+            @endif
+            @if(($event['is_last_day'] ?? true) && isset($event['end_time']))
+                @if(($event['is_first_day'] ?? true) && isset($event['start_time']))
+                    -
+                @endif
+                {{ $event['end_time'] }}
+            @endif
+        </p>
+    @endif
 </div>

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -207,8 +207,67 @@ class LivewireCalendar extends Component
     {
         return $events
             ->filter(function ($event) use ($day) {
-                return Carbon::parse($event['date'])->isSameDay($day);
+                return $this->eventOccursOnDay($event, $day);
+            })
+            ->map(function ($event) use ($day) {
+                return $this->enrichEventForDay($event, $day);
             });
+    }
+
+    /**
+     * Determine if an event occurs on a given day.
+     * Supports legacy 'date' field and new 'start_date'/'end_date' fields.
+     */
+    protected function eventOccursOnDay(array $event, Carbon $day): bool
+    {
+        // New multi-day format takes precedence
+        if (isset($event['start_date']) && isset($event['end_date'])) {
+            $startDate = Carbon::parse($event['start_date'])->startOfDay();
+            $endDate = Carbon::parse($event['end_date'])->startOfDay();
+            $checkDay = $day->copy()->startOfDay();
+
+            return $checkDay->between($startDate, $endDate);
+        }
+
+        // Fallback to legacy 'date' field
+        if (isset($event['date'])) {
+            return Carbon::parse($event['date'])->isSameDay($day);
+        }
+
+        return false;
+    }
+
+    /**
+     * Enrich event with day-specific metadata for view rendering.
+     * Adds position info (is_first_day, is_last_day, is_multiday, day_position).
+     */
+    protected function enrichEventForDay(array $event, Carbon $day): array
+    {
+        // Legacy single-day events - add minimal metadata
+        if (!isset($event['start_date']) || !isset($event['end_date'])) {
+            $event['is_multiday'] = false;
+            $event['is_first_day'] = true;
+            $event['is_last_day'] = true;
+            $event['day_position'] = 1;
+            $event['total_days'] = 1;
+
+            return $event;
+        }
+
+        $startDate = Carbon::parse($event['start_date'])->startOfDay();
+        $endDate = Carbon::parse($event['end_date'])->startOfDay();
+        $checkDay = $day->copy()->startOfDay();
+
+        $totalDays = $startDate->diffInDays($endDate) + 1;
+        $dayPosition = $startDate->diffInDays($checkDay) + 1;
+
+        $event['is_multiday'] = $totalDays > 1;
+        $event['is_first_day'] = $checkDay->isSameDay($startDate);
+        $event['is_last_day'] = $checkDay->isSameDay($endDate);
+        $event['day_position'] = $dayPosition;
+        $event['total_days'] = $totalDays;
+
+        return $event;
     }
 
     public function onDayClick($year, $month, $day)

--- a/src/LivewireCalendarServiceProvider.php
+++ b/src/LivewireCalendarServiceProvider.php
@@ -26,7 +26,7 @@ class LivewireCalendarServiceProvider extends ServiceProvider
 
         Blade::directive('livewireCalendarScripts', function () {
             return <<<'HTML'
-            <script>
+            <script data-navigate-once>
                 function onLivewireCalendarEventDragStart(event, eventId) {
                     event.dataTransfer.setData('id', eventId);
                 }
@@ -36,7 +36,9 @@ class LivewireCalendarServiceProvider extends ServiceProvider
                     event.preventDefault();
 
                     let element = document.getElementById(`${componentId}-${dateString}`);
-                    element.className = element.className + ` ${dragAndDropClasses} `;
+                    if (element) {
+                        element.className = element.className + ` ${dragAndDropClasses} `;
+                    }
                 }
 
                 function onLivewireCalendarEventDragLeave(event, componentId, dateString, dragAndDropClasses) {
@@ -44,7 +46,9 @@ class LivewireCalendarServiceProvider extends ServiceProvider
                     event.preventDefault();
 
                     let element = document.getElementById(`${componentId}-${dateString}`);
-                    element.className = element.className.replace(dragAndDropClasses, '');
+                    if (element) {
+                        element.className = element.className.replace(dragAndDropClasses, '');
+                    }
                 }
 
                 function onLivewireCalendarEventDragOver(event) {
@@ -57,11 +61,17 @@ class LivewireCalendarServiceProvider extends ServiceProvider
                     event.preventDefault();
 
                     let element = document.getElementById(`${componentId}-${dateString}`);
-                    element.className = element.className.replace(dragAndDropClasses, '');
+                    if (element) {
+                        element.className = element.className.replace(dragAndDropClasses, '');
+                    }
 
                     const eventId = event.dataTransfer.getData('id');
 
-                    window.Livewire.find(componentId).call('onEventDropped', eventId, year, month, day);
+                    // Livewire 3/4 compatible - call method directly on $wire object
+                    const $wire = window.Livewire.find(componentId);
+                    if ($wire) {
+                        $wire.onEventDropped(eventId, year, month, day);
+                    }
                 }
             </script>
 HTML;

--- a/tests/LivewireCalendarTest.php
+++ b/tests/LivewireCalendarTest.php
@@ -2,6 +2,8 @@
 
 namespace Omnia\LivewireCalendar\Tests;
 
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Omnia\LivewireCalendar\LivewireCalendar;
 use Livewire\Livewire;
 
@@ -72,5 +74,231 @@ class LivewireCalendarTest extends TestCase
             today()->endOfMonth()->startOfDay(),
             $component->get('endsAt')
         );
+    }
+
+    public function test_legacy_single_day_event_shows_on_correct_day()
+    {
+        $calendar = new LivewireCalendar();
+        $today = Carbon::today();
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Single Day Event',
+                'date' => $today,
+            ]
+        ]);
+
+        $result = $calendar->getEventsForDay($today, $events);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(1, $result->first()['id']);
+        $this->assertFalse($result->first()['is_multiday']);
+    }
+
+    public function test_legacy_event_does_not_show_on_wrong_day()
+    {
+        $calendar = new LivewireCalendar();
+        $today = Carbon::today();
+        $tomorrow = Carbon::tomorrow();
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Single Day Event',
+                'date' => $today,
+            ]
+        ]);
+
+        $result = $calendar->getEventsForDay($tomorrow, $events);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function test_multiday_event_shows_on_all_days_in_range()
+    {
+        $calendar = new LivewireCalendar();
+        $startDate = Carbon::today();
+        $endDate = Carbon::today()->addDays(2);
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Multi-Day Event',
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ]
+        ]);
+
+        // Should appear on day 1 (start)
+        $result = $calendar->getEventsForDay($startDate, $events);
+        $this->assertCount(1, $result);
+        $this->assertTrue($result->first()['is_first_day']);
+        $this->assertFalse($result->first()['is_last_day']);
+        $this->assertTrue($result->first()['is_multiday']);
+
+        // Should appear on day 2 (middle)
+        $result = $calendar->getEventsForDay($startDate->copy()->addDay(), $events);
+        $this->assertCount(1, $result);
+        $this->assertFalse($result->first()['is_first_day']);
+        $this->assertFalse($result->first()['is_last_day']);
+
+        // Should appear on day 3 (end)
+        $result = $calendar->getEventsForDay($endDate, $events);
+        $this->assertCount(1, $result);
+        $this->assertFalse($result->first()['is_first_day']);
+        $this->assertTrue($result->first()['is_last_day']);
+    }
+
+    public function test_multiday_event_does_not_show_outside_range()
+    {
+        $calendar = new LivewireCalendar();
+        $startDate = Carbon::today();
+        $endDate = Carbon::today()->addDays(2);
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Multi-Day Event',
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ]
+        ]);
+
+        // Should NOT appear before start
+        $result = $calendar->getEventsForDay($startDate->copy()->subDay(), $events);
+        $this->assertCount(0, $result);
+
+        // Should NOT appear after end
+        $result = $calendar->getEventsForDay($endDate->copy()->addDay(), $events);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_event_with_same_start_and_end_date_is_single_day()
+    {
+        $calendar = new LivewireCalendar();
+        $today = Carbon::today();
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Same Day Event',
+                'start_date' => $today,
+                'end_date' => $today,
+            ]
+        ]);
+
+        $result = $calendar->getEventsForDay($today, $events);
+
+        $this->assertCount(1, $result);
+        $this->assertFalse($result->first()['is_multiday']);
+        $this->assertEquals(1, $result->first()['total_days']);
+    }
+
+    public function test_event_day_position_is_calculated_correctly()
+    {
+        $calendar = new LivewireCalendar();
+        $startDate = Carbon::today();
+        $endDate = Carbon::today()->addDays(4); // 5 day event
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Five Day Event',
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ]
+        ]);
+
+        // Check day 3 (middle)
+        $day3 = $startDate->copy()->addDays(2);
+        $result = $calendar->getEventsForDay($day3, $events);
+
+        $this->assertEquals(3, $result->first()['day_position']);
+        $this->assertEquals(5, $result->first()['total_days']);
+    }
+
+    public function test_start_date_takes_precedence_over_legacy_date()
+    {
+        $calendar = new LivewireCalendar();
+        $legacyDate = Carbon::today();
+        $startDate = Carbon::today()->addDays(5);
+        $endDate = Carbon::today()->addDays(7);
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Mixed Format Event',
+                'date' => $legacyDate,  // Legacy field - should be ignored
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ]
+        ]);
+
+        // Should NOT appear on legacy date
+        $result = $calendar->getEventsForDay($legacyDate, $events);
+        $this->assertCount(0, $result);
+
+        // Should appear on start_date
+        $result = $calendar->getEventsForDay($startDate, $events);
+        $this->assertCount(1, $result);
+    }
+
+    public function test_multiple_events_on_same_day()
+    {
+        $calendar = new LivewireCalendar();
+        $today = Carbon::today();
+
+        $events = collect([
+            [
+                'id' => 1,
+                'title' => 'Legacy Event',
+                'date' => $today,
+            ],
+            [
+                'id' => 2,
+                'title' => 'Multi-Day Event (day 2 of 3)',
+                'start_date' => $today->copy()->subDay(),
+                'end_date' => $today->copy()->addDay(),
+            ],
+            [
+                'id' => 3,
+                'title' => 'Single Day New Format',
+                'start_date' => $today,
+                'end_date' => $today,
+            ]
+        ]);
+
+        $result = $calendar->getEventsForDay($today, $events);
+
+        $this->assertCount(3, $result);
+    }
+
+    public function test_drag_and_drop_enabled_by_default()
+    {
+        $component = $this->createComponent([]);
+
+        $this->assertTrue($component->get('dragAndDropEnabled'));
+    }
+
+    public function test_drag_and_drop_can_be_disabled()
+    {
+        $component = $this->createComponent(['dragAndDropEnabled' => false]);
+
+        $this->assertFalse($component->get('dragAndDropEnabled'));
+    }
+
+    public function test_drag_and_drop_classes_have_default()
+    {
+        $component = $this->createComponent([]);
+
+        $this->assertEquals('border border-blue-400 border-4', $component->get('dragAndDropClasses'));
+    }
+
+    public function test_custom_drag_and_drop_classes()
+    {
+        $component = $this->createComponent(['dragAndDropClasses' => 'bg-blue-100']);
+
+        $this->assertEquals('bg-blue-100', $component->get('dragAndDropClasses'));
     }
 }


### PR DESCRIPTION
## Summary
Fixes GitHub issues #31 and #32 by adding multi-day event support and improving drag-drop compatibility with Livewire 3/4 SPA mode.

**Issue #31**: Multi-day events now span across all days using `start_date`/`end_date` fields with full backwards compatibility with the legacy `date` field.

**Issue #32**: Drag-drop functionality now uses Alpine.js instead of inline handlers, enabling proper SPA support and Livewire 3/4 compatibility with the `$wire` object.

## Tests
All 16 tests pass, including 12 new tests covering multi-day event logic and drag-drop configuration.