### PR TITLE
Rebrand to Omnia Church Apps

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Omnia Digital
+Copyright (c) Omnia Church Apps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### Security
 
-If you discover any security related issues, please email us at info@omniadigital.io instead of using the issue tracker.
+If you discover any security related issues, please email us at info@omnia.church instead of using the issue tracker.
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel Livewire calendar component",
     "keywords": [
         "omnia",
-        "omnia-digital",
+        "omnia-church-apps",
         "livewire-calendar"
     ],
     "homepage": "https://github.com/omnia-digital/livewire-calendar",
@@ -12,7 +12,7 @@
     "authors": [
         {
             "name": "Josh Torres",
-            "email": "josht@omniadigital.io",
+            "email": "info@omnia.church",
             "role": "Developer"
         },
         {
@@ -22,7 +22,7 @@
         },
         {
             "name": "Osei Quashie",
-            "email": "osei@omniadigital.io",
+            "email": "info@omnia.church",
             "role": "Developer"
         }
     ],


### PR DESCRIPTION
Update branding from Omnia Digital to Omnia Church Apps across README, LICENSE, and composer.json. Changes include updating copyright, security email, keywords, and author emails to use the omnia.church domain.